### PR TITLE
Fix root path in breadcrumb

### DIFF
--- a/Vue_Full_Project/src/components/Breadcrumb.vue
+++ b/Vue_Full_Project/src/components/Breadcrumb.vue
@@ -1,7 +1,7 @@
 <template>
   <ol class="breadcrumb">
     <li class="breadcrumb-item" v-for="(item, index) in list"><span class="active" v-if="isLast(index)">{{ showName(item) }}</span>
-      <router-link :to="item.path" v-else>{{ showName(item) }}</router-link>
+      <router-link :to="adjustPath(item)" v-else>{{ showName(item) }}</router-link>
     </li>
   </ol>
 </template>
@@ -16,6 +16,9 @@ export default {
     }
   },
   methods: {
+    adjustPath (item) {
+      return item.path === '' ? '/' : item.path
+    },
     isLast (index) {
       return index === this.list.length - 1
     },


### PR DESCRIPTION
If blank, set to root.  My this.$route.matched sets the root (Home) path to a blank string