### PR TITLE
fix(jest): localStorage not avail 4 opaque origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [vue](./README.md) version `changelog`
 
+##### `v2.0.0-beta.13`
+- fix(jest.config.js): solves - _SecurityError: localStorage is not available for opaque origins_
+- chore: update `bootstrap` to `4.1.3`
+- chore: update `@vue/cli-plugin-babel` to `3.0.0-rc.7`
+- chore: update `@vue/cli-plugin-e2e-nightwatch` to `3.0.0-rc.7`
+- chore: update `@vue/cli-plugin-eslint` to `3.0.0-rc.7`
+- chore: update `@vue/cli-plugin-unit-jest` to `3.0.0-rc.7`
+- chore: update `@vue/cli-service` to `3.0.0-rc.7`
+
 ##### `v2.0.0-beta.7`
 - refactor(Footer): move default footer to the template
 - fix(Footer): IE sticky footer issue

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,5 +19,7 @@ module.exports = {
   testMatch: [
     '<rootDir>/(tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx))',
     '<rootDir>/tests/unit/Dashboard.spec.js'
-  ]
+  ],
+  verbose: true,
+  testURL: "http://localhost/"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coreui/coreui-free-vue-admin-template",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.13",
   "description": "Open Source Bootstrap Admin Template",
   "author": "Łukasz Holeczek",
   "homepage": "http://coreui.io",
@@ -18,7 +18,7 @@
     "@coreui/coreui-plugin-chartjs-custom-tooltips": "^1.2.0",
     "@coreui/icons": "0.2.0",
     "@coreui/vue": "^2.0.0-rc.3",
-    "bootstrap": "^4.1.2",
+    "bootstrap": "^4.1.3",
     "bootstrap-vue": "^2.0.0-rc.11",
     "chart.js": "^2.7.2",
     "core-js": "^2.5.7",
@@ -33,11 +33,11 @@
     "vue-router": "^3.0.1"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.0.0-rc.5",
-    "@vue/cli-plugin-e2e-nightwatch": "^3.0.0-rc.5",
-    "@vue/cli-plugin-eslint": "^3.0.0-rc.5",
-    "@vue/cli-plugin-unit-jest": "^3.0.0-rc.5",
-    "@vue/cli-service": "^3.0.0-rc.5",
+    "@vue/cli-plugin-babel": "^3.0.0-rc.7",
+    "@vue/cli-plugin-e2e-nightwatch": "^3.0.0-rc.7",
+    "@vue/cli-plugin-eslint": "^3.0.0-rc.7",
+    "@vue/cli-plugin-unit-jest": "^3.0.0-rc.7",
+    "@vue/cli-service": "^3.0.0-rc.7",
     "@vue/test-utils": "^1.0.0-beta.21",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.0",


### PR DESCRIPTION
- fix(jest.config.js): solves - _SecurityError: localStorage is not available for opaque origins_
- chore: update `vue-cli` to `3.0.0-rc.7`
- chore: update `bootstrap` to `4.1.3`