### PR TITLE
Pass-through row-clicked event in cTable

### DIFF
--- a/src/views/base/Table.vue
+++ b/src/views/base/Table.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card :header="caption">
-    <b-table :dark="dark" :hover="hover" :striped="striped" :bordered="bordered" :small="small" :fixed="fixed" responsive="sm" :items="items" :fields="captions" :current-page="currentPage" :per-page="perPage">
+    <b-table :dark="dark" :hover="hover" :striped="striped" :bordered="bordered" :small="small" :fixed="fixed" responsive="sm" :items="items" :fields="captions" :current-page="currentPage" :per-page="perPage" @row-clicked="$emit('row-clicked')">
       <template slot="status" slot-scope="data">
         <b-badge :variant="getBadge(data.item.status)">{{data.item.status}}</b-badge>
       </template>


### PR DESCRIPTION
When directly using the cTable component, the row-clicked event is not passed. The enclosed patch allows for direct usage of the cTable and using `@row-clicked="rowClicked"`.