### PR TITLE
Fix table header not to be escaped

### DIFF
--- a/src/views/base/Table.vue
+++ b/src/views/base/Table.vue
@@ -1,5 +1,7 @@
 <template>
-  <b-card :header="caption">
+  <b-card>
+    <span slot="header" v-html="caption"></span>
+    <b-card-text>
     <b-table :dark="dark" :hover="hover" :striped="striped" :bordered="bordered" :small="small" :fixed="fixed" responsive="sm" :items="items" :fields="captions" :current-page="currentPage" :per-page="perPage">
       <template slot="status" slot-scope="data">
         <b-badge :variant="getBadge(data.item.status)">{{data.item.status}}</b-badge>
@@ -8,6 +10,7 @@
     <nav>
       <b-pagination :total-rows="totalRows" :per-page="perPage" v-model="currentPage" prev-text="Prev" next-text="Next" hide-goto-end-buttons/>
     </nav>
+    </b-card-text>
   </b-card>
 </template>
 


### PR DESCRIPTION
The <i> tag for the table header was exposed because of the escaped html syntax passed as prop.

It can be fixed by using 'v-html' attribute.

If exposing the raw html code on table header is not intended, I suggest to modify the Table component like this.

- Before Modification:
![](https://user-images.githubusercontent.com/17661005/53676901-de88d000-3ceb-11e9-81bb-9a7cc327b0b2.png)

- After Modification:
![](https://user-images.githubusercontent.com/17661005/53676896-d892ef00-3ceb-11e9-8043-04f3a42e58ff.png)