### PR TITLE
v2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [CoreUI for Vue.js](./README.md) version `changelog`
 
+##### `v2.1.5`
+- fix(Forms): textarea is not textarea #161 - thanks @l2aelba
+- chore: lock `bootstrap-vue` to `2.0.0-rc.24`
+
 ##### `v2.1.4`
 - fix(jest.config): babel-jest can't process import statement
 - chore(package.json): add missing `repository` url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coreui/coreui-free-vue-admin-template",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Open Source Bootstrap Admin Template",
   "author": "Łukasz Holeczek",
   "homepage": "http://coreui.io",
@@ -24,7 +24,7 @@
     "@coreui/icons": "0.3.0",
     "@coreui/vue": "^2.1.2",
     "bootstrap": "^4.3.1",
-    "bootstrap-vue": "^2.0.0-rc.24",
+    "bootstrap-vue": "2.0.0-rc.24",
     "chart.js": "^2.8.0",
     "core-js": "^2.6.9",
     "css-vars-ponyfill": "^2.0.2",

--- a/src/views/base/Forms.vue
+++ b/src/views/base/Forms.vue
@@ -152,7 +152,7 @@
             label-for="basicTextarea"
             :label-cols="3"
             >
-            <b-form-input id="basicTextarea" :textarea="true" :rows="9" placeholder="Content.."></b-form-input>
+            <b-form-textarea id="basicTextarea" :rows="9" placeholder="Content.."></b-form-textarea>
           </b-form-group>
           <b-form-group
             label="Select"

--- a/tests/unit/views/base/__snapshots__/Forms.spec.js.snap
+++ b/tests/unit/views/base/__snapshots__/Forms.spec.js.snap
@@ -450,13 +450,12 @@ exports[`Forms.vue renders correctly 1`] = `
             labelcols="3"
             labelfor="basicTextarea"
           >
-            <b-form-input-stub
+            <b-form-textarea-stub
               id="basicTextarea"
               placeholder="Content.."
               rows="9"
-              textarea="true"
-              type="text"
               value=""
+              wrap="soft"
             />
           </b-form-group-stub>
            


### PR DESCRIPTION
##### `v2.1.5`
- fix(Forms): textarea is not textarea closes #161 - thanks @l2aelba
- chore: lock `bootstrap-vue` to `2.0.0-rc.24`