### PR TITLE
make 'export default new Router' more readable

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -60,11 +60,8 @@ const User = () => import('@/views/users/User')
 
 Vue.use(Router)
 
-export default new Router({
-  mode: 'hash', // https://router.vuejs.org/api/#mode
-  linkActiveClass: 'open active',
-  scrollBehavior: () => ({ y: 0 }),
-  routes: [
+function configRoutes() {
+  return [
     {
       path: '/',
       redirect: '/dashboard',
@@ -333,4 +330,11 @@ export default new Router({
       ]
     }
   ]
+}
+
+export default new Router({
+  mode: 'hash', // https://router.vuejs.org/api/#mode
+  linkActiveClass: 'open active',
+  scrollBehavior: () => ({ y: 0 }),
+  routes: configRoutes()
 })


### PR DESCRIPTION
make export default new Router more readable by separating routes into a configRoutes() function