### PR TITLE
feat: dont load package.json file directly into vue components. 

### DIFF
--- a/src/components/DocsCallout.vue
+++ b/src/components/DocsCallout.vue
@@ -22,7 +22,8 @@
 </template>
 
 <script>
-import packageJson from '../../package.json'
+import { useStore } from 'vuex'
+
 export default {
   name: 'DocsCallout',
   props: {
@@ -44,7 +45,8 @@ export default {
     plural: Boolean,
   },
   setup(props) {
-    const url = `https://coreui.io/vue/docs/${packageJson.config.coreui_library_short_version}/${props.url}`
+    const store = useStore()
+    const url = `https://coreui.io/vue/docs/${store.getters.coreuiLibraryShortVersion}/${props.href}`
 
     return {
       url,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,8 @@
 import { createStore } from 'vuex'
 
+const COREUI_LIBRARY_SHORT_VERSION =
+  process.env.COREUI_LIBRARY_SHORT_VERSION || ''
+
 export default createStore({
   state: {
     sidebarVisible: '',
@@ -14,6 +17,11 @@ export default createStore({
     },
     updateSidebarVisible(state, payload) {
       state.sidebarVisible = payload.value
+    },
+  },
+  getters: {
+    coreuiLibraryShortVersion() {
+      return COREUI_LIBRARY_SHORT_VERSION
     },
   },
   actions: {},

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,19 @@
+const { DefinePlugin } = require('webpack')
 const { defineConfig } = require('@vue/cli-service')
+const fs = require('fs')
+const packageJson = fs.readFileSync('./package.json')
+const coreuiLibraryShortVersion =
+  JSON.parse(packageJson).config.coreui_library_short_version || ''
+
 module.exports = defineConfig({
   transpileDependencies: true,
+  configureWebpack: {
+    plugins: [
+      new DefinePlugin({
+        'process.env': {
+          COREUI_LIBRARY_SHORT_VERSION: '"' + coreuiLibraryShortVersion + '"',
+        },
+      }),
+    ],
+  },
 })


### PR DESCRIPTION
It is bad practice to load the package.json file directly into your codebase. Instead extract needed values as ENVs and use them. As this project is also in use by newbies, I thought that this change is neccessary so that they dont adapt these practice to their projects. 

PS.: The link to the docs is also false, I corrected it. You can see that [here](https://coreui.io/vue/demo/4.0/free/#/base/accordion). The link for the accordion docs refers to "undefined". 