### PR TITLE
fix import issue and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ CoreUI is meant to be the UX game changer. Pure & transparent code is devoid of 
 - [Download the latest release](https://github.com/coreui/coreui-free-vue-admin-template/archive/refs/heads/main.zip)
 - Clone the repo: `git clone https://github.com/coreui/coreui-free-vue-admin-template.git`
 
-### Instalation
+### Installation
 
 ``` bash
 $ npm install

--- a/src/components/AppBreadcrumb.vue
+++ b/src/components/AppBreadcrumb.vue
@@ -27,7 +27,7 @@ onMounted(() => {
   <CBreadcrumb class="my-0">
     <CBreadcrumbItem
       v-for="item in breadcrumbs"
-      :key="item"
+      :key="item.path"
       :href="item.active ? '' : item.path"
       :active="item.active"
     >

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -286,22 +286,22 @@ const routes = [
       {
         path: '404',
         name: 'Page404',
-        component: () => import('@/views/pages/Page404'),
+        component: () => import('@/views/pages/Page404.vue'),
       },
       {
         path: '500',
         name: 'Page500',
-        component: () => import('@/views/pages/Page500'),
+        component: () => import('@/views/pages/Page500.vue'),
       },
       {
         path: 'login',
         name: 'Login',
-        component: () => import('@/views/pages/Login'),
+        component: () => import('@/views/pages/Login.vue'),
       },
       {
         path: 'register',
         name: 'Register',
-        component: () => import('@/views/pages/Register'),
+        component: () => import('@/views/pages/Register.vue'),
       },
     ],
   },


### PR DESCRIPTION
# Fix: Import Extensions, Breadcrumb Key, and README Typo

## Summary
Fixes three code quality issues: missing `.vue` extensions in router imports, invalid breadcrumb key prop, and README typo.

## Changes

### 1. Added `.vue` Extensions to Router Imports

### 2. Fixed Breadcrumb Key Prop

### 3. Fixed README Typo